### PR TITLE
Add multiline support for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,14 @@ In the above example, the first secret section is `db/sqlusername|sql_username`.
 
 The second secret section is `db/sql_password`.  When no name is given for the environment variable, the Conjur Variable Name will be used.  In this example, the value would be set to `SQL_PASSWORD` as the environment variable name.
 
+### Multiline
+```
+secrets: |
+   db/sqlusername|sql_username;
+   db/sql_password;
+```
+For improved readability the secret section accepts multiline values.  The `|` separates the Conjur Variable ID from the environment variable that will contain the value of the Conjur Variable's value.  `;` and `newline` separate the secrets sections.
+
 ## Security
 
 ### Protecting Arguments

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,11 @@ conjur_authn() {
 }
 
 array_secrets() {
+    # Check if the input contains ";\n" and replace it with ";"
+    if [[ "$INPUT_SECRETS" == *";"$'\n'* ]]; then
+        INPUT_SECRETS=$(sed ':a;N;$!ba;s/;\n/;/g' <<< "$INPUT_SECRETS")
+    fi
+
     IFS=';'
     read -ra SECRETS <<< "$INPUT_SECRETS" # [0]=db/sqlusername | sql_username [1]=db/sql_password
 }


### PR DESCRIPTION
### Desired Outcome

Currently the action just accepts single line values for the secret section. If you need to access multiple secrets this is difficult to read and maintain. 
I'm introducing a multiline capability so it's easier to maintain multiple secrets.

### Implemented Changes

*Describe how the desired outcome above has been achieved with this PR. In
particular, consider:*
I've changed the parsing of the `INPUT_SECRET` inside the `entrypoint.sh`. If a multiline string is detected the `new lines` are removed, so it's continued to be parsed as a single line string.

### Connected Issue/Story

Resolves #[cyberark/conjur-action/issues/12]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
