### PR TITLE
Calculate differences between IAT and EPOCHSECONDS

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'CyberArk Conjur Secret Fetcher Action'
-description: 'Securely retrieve a secret from CyberArk Conjur Secrets Manager and present to your action as a masked environment variable'
+description: 'Securely retrieve a secret from CyberArk Conjur Secrets Manager and present to your action as a masked environment variable.'
 author: 'CyberArk'
 inputs: 
   url:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,7 +73,7 @@ conjur_authn() {
 	if [[ -n "$INPUT_AUTHN_ID" ]]; then
 
 		echo "::debug Authenticate via Authn-JWT"
-        JWT_TOKEN=$(handle_git_jwt)
+		JWT_TOKEN=$(handle_git_jwt)
         
 		if [[ -n "$INPUT_CERTIFICATE" ]]; then
             echo "::debug Authenticating with certificate"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ conjur_authn() {
 
 		echo "::debug Authenticate via Authn-JWT"
 		JWT_TOKEN=$(curl -H "Authorization:bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r .value )
+        sleep 5
         
 		if [[ -n "$INPUT_CERTIFICATE" ]]; then
             echo "::debug Authenticating with certificate"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,7 @@ conjur_authn() {
 
 		echo "::debug Authenticate via Authn-JWT"
 		JWT_TOKEN=$(curl -H "Authorization:bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r .value )
-        sleep 5
+		sleep 5
         
 		if [[ -n "$INPUT_CERTIFICATE" ]]; then
             echo "::debug Authenticating with certificate"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,15 +32,48 @@ create_pem() {
     echo "$INPUT_CERTIFICATE" > conjur_"$INPUT_ACCOUNT".pem
 }
 
+handle_git_jwt() {
+    ## Handle JWT Token epoch time sync
+    
+    # Grab JWT Token from git IDP
+    local JWT_TOKEN=$( curl -s -H "Authorization:bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r .value )
+    # Parse payload body
+    j_body=$( echo "$JWT_TOKEN" | cut -d "." -f 2 )
+    # Repad b64 token (dirty)
+    padd="=="
+    jwt_padded="${j_body}${padd}"
+    #decode payload body
+    payload=$(echo "$jwt_padded" | base64 -d)
+    # capture IAT time
+    iat=$( echo "$payload" | jq .iat )
+
+    # Check if IAT less than or equal to server epoch
+    if (( "$iat" <= "$EPOCHSECONDS" )); then
+
+        echo "::debug No delta between iat [$iat] and epoch [$EPOCHSECONDS]"
+        echo "$JWT_TOKEN"
+
+    # check if IAT greater than server epoch, if so, calculate delta and sleep before returning
+    elif (( "$iat" > "$EPOCHSECONDS" )); then
+
+        delta=$(( "$iat" - "$EPOCHSECONDS" ))
+        echo "::debug delta found: iat [$iat] // epoch [$EPOCHSECONDS]; sleeping for $delta seconds"
+        sleep "$delta"
+        echo "$JWT_TOKEN"
+
+    else
+        echo "::debug unhandled problem"
+        exit 1 
+    fi
+    ####
+}
+
 conjur_authn() {
 
 	if [[ -n "$INPUT_AUTHN_ID" ]]; then
 
 		echo "::debug Authenticate via Authn-JWT"
-		JWT_TOKEN=$(curl -H "Authorization:bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r .value )
-		# Sleeping for 5 seconds due to issue with IAT claim not being valid when sent immediately to Conjur. 
-		# This will ensure token validity when using JWT and Github
-		sleep 5
+        JWT_TOKEN=$(handle_git_jwt)
         
 		if [[ -n "$INPUT_CERTIFICATE" ]]; then
             echo "::debug Authenticating with certificate"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,8 @@ conjur_authn() {
 
 		echo "::debug Authenticate via Authn-JWT"
 		JWT_TOKEN=$(curl -H "Authorization:bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL" | jq -r .value )
+		# Sleeping for 5 seconds due to issue with IAT claim not being valid when sent immediately to Conjur. 
+		# This will ensure token validity when using JWT and Github
 		sleep 5
         
 		if [[ -n "$INPUT_CERTIFICATE" ]]; then


### PR DESCRIPTION
### Desired Outcome

Delay Conjur & JWT authentication based on delta calculated from `iat` and `EPOCHSECONDS`. This will ensure token validity from `iat` and github runners.

### Implemented Changes

In this PR:

[Implemented handle_git_jwt](https://github.com/aharriscybr/conjur-action/blob/master/entrypoint.sh#L35) - this function decodes and captures `iat` from issued JWT token from git IDP. With the decoded `iat` we check local `EPOCHSECONDS`, calculate a delta:
If there is a delta, delay for the delta in seconds
If there is no delta, authenticate to conjur

### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]
#14 

CyberArk internal issue ID: N/A

### Definition of Done
@cyberark/integrations-factory test and review

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes
